### PR TITLE
Updated import extractor

### DIFF
--- a/import_extractor.py
+++ b/import_extractor.py
@@ -1,39 +1,79 @@
 import ast
 import distutils.sysconfig as sysconfig
-import imp
+import importlib
+import importlib.util
 import pathlib
 import pkgutil
 import os
 import sys
 
-built_in_modules = set(sys.builtin_module_names)
-built_in_modules.update({
-    module
-    for _, module, package in pkgutil.iter_modules()
-    if package is False
-})
-std_lib = sysconfig.get_python_lib(standard_lib=True)
-for top in pathlib.Path(std_lib).iterdir():
-    if str(top).startswith(('dist-packages', 'site-packages')):
-        continue
-    built_in_modules.add(str(top).split('.')[0])
 
 external_modules = set()
 
+tribler_source_dirs = [
+    os.path.join(sys.argv[1], 'src'),
+    os.path.join(sys.argv[1], 'src', 'anydex'),
+    os.path.join(sys.argv[1], 'src', 'pyipv8'),
+    os.path.join(sys.argv[1], 'src', 'tribler-common'),
+    os.path.join(sys.argv[1], 'src', 'tribler-core'),
+    os.path.join(sys.argv[1], 'src', 'tribler-gui')
+]
+sys.path.extend(tribler_source_dirs)
+original_sys_path = sys.path
+naked_sys_path = [os.path.dirname(os.path.dirname(importlib.__file__))]
+naked_sys_path.append(os.path.join(naked_sys_path[0], 'lib-dynload'))
 
-def is_external_module(top_path, path, name):
+global_imports = set()
+local_imports = set()
+
+
+def is_external_module(path, name):
     """
     Check if we can import this module from somewhere in the local file structure.
     (Filter out imports within the workspace)
     """
+    # The AST "module" field may be None
     if not name:
         return
-    name = name.split('.')[0]
-    if name not in built_in_modules:
-        try:
-            imp.find_module(name, [os.path.dirname(path), path, top_path])
-        except ImportError:
-            external_modules.add(name)
+
+    # Normalize the name to the package, e.g.:
+    #  ..bar in foo/bar.py becomes foo.bar
+    for source_path in tribler_source_dirs:
+        if path.startswith(source_path):
+            local_path = path[len(source_path)+1:]
+            name = importlib.util.resolve_name(name, local_path.replace(os.sep, '.') or path.split(os.sep)[-1])
+    package_name = name.split('.')[0]
+
+    # Strip all external import paths and reload.
+    # Anything imported at level 0 at this point is a standard library.
+    try:
+        naked_sys = importlib.reload(sys)
+        naked_sys.path = ['/usr/lib/python3.8', '/usr/lib/python3.8/lib-dynload']
+        imported = __import__(package_name, globals={'sys': naked_sys}, locals={}, level=0)
+        if ((not getattr(imported, '__file__', None))
+                or ('site-packages' not in imported.__file__ and 'dist-packages' not in imported.__file__)):
+            global_imports.add(package_name)
+            return
+    except ImportError:
+        # This is not a standard library, continue.
+        pass
+
+    # Reinstate the source imports and attempt to import again.
+    # Anything not reachable from this location is truly an external import.
+    try:
+        original_sys = importlib.reload(sys)
+        original_sys.path = original_sys_path
+        imported = __import__(package_name, globals={'sys': original_sys}, locals={}, level=0)
+        if ((not getattr(imported, '__file__', None))
+                or ('site-packages' not in imported.__file__ and 'dist-packages' not in imported.__file__)):
+            local_imports.add(package_name)
+            return
+    except ImportError:
+        # The module could not be imported, it is not a standard library and also not in our local scope.
+        external_modules.add(package_name)
+    # The module could be imported, but it is not a standard library or in our local scope.
+    external_modules.add(package_name)
+
 
 location = os.path.abspath(sys.argv[1])
 for dirpath, dirnames, filenames in os.walk(location):
@@ -48,11 +88,14 @@ for dirpath, dirnames, filenames in os.walk(location):
             for subnode in ast.walk(node):
                 if isinstance(subnode, ast.Import):
                     for import_name in (alias.name for alias in subnode.names):
-                        is_external_module(location, dirpath, import_name)
+                        is_external_module(dirpath, import_name)
                 if isinstance(subnode, ast.ImportFrom):
-                    is_external_module(location, dirpath, subnode.module)
+                    if subnode.module is not None:
+                        is_external_module(dirpath, '.' * subnode.level + subnode.module)
         except:
             print("ERROR: Failed to parse", filename, file=sys.stderr)
 
-for name in sorted(external_modules):
-    print(name)
+
+for external_name in sorted(external_modules):
+    print(external_name)
+


### PR DESCRIPTION
Fixes #5

This PR:

 - Replaces the deprecated `imp` module.
 - Infers system modules from `sys` instead of querying different libraries.
 - Greatly reduces the false positives.

Output for the current Tribler version (see https://jenkins-ci.tribler.org/job/GH_Tribler_PR_Tests/job/PR_new_imports_check/575//artifact/output/import_report.html for a recent run with our current import extractor script):

```
PIL
PyQt5
__scriptpath__
_winreg
aiohttp
aiohttp_apispec
apispec
async_timeout
asynctest
bitcoinlib
chardet
configobj
coverage
cryptography
decorator
distro
github
libnacl
libtorrent
lz4
marshmallow
meliae
mock
msvcrt
netifaces
networkx
nose
numpy
pony
psutil
pyasn1
pyqtgraph
pysqlite2
qrcode
requests
setuptools
six
sqlalchemy
twisted
urllib3
validate
win32api
win32com
win32file
winreg
yaml
yappi
```

Note that there are still some false positives left. Like `__scriptpath__` which is part of IPv8 stresstest importing and the `win32*` libaries which do not exist when run on UNIX.